### PR TITLE
No need to overwrite the content-length anymore

### DIFF
--- a/lib/http/json.js
+++ b/lib/http/json.js
@@ -25,7 +25,6 @@
 		//console.log("http req : send : ", infos);
 		if(datas) {
 			var stringifiedDatas = JSON.stringify(datas);
-			infos.headers['Content-Length'] = stringifiedDatas.length;
 		}
 
 		var maxRedirections = options.maxRedirections || 10;


### PR DESCRIPTION
Les derniers changements d'Autobahn permettent de conserver le header de la requête, et les browsers envoient déjà le header content-length.

Étant donné que le résultat de `stringifiedDatas.length` pouvait parfois différer du header envoyé par le browser, les données étaient parfois tronquées à l'arrivée sur le serveur distant.
